### PR TITLE
XPath: little code generation improvement

### DIFF
--- a/Twig.pm
+++ b/Twig.pm
@@ -6759,7 +6759,7 @@ sub next_siblings
                         }
                     }
                   #warn "step: '$step'";
-                  $sub .= "\@results= grep { \$_ } map { $step } \@results;"; 
+                  $sub .= "\@results= grep defined, map { $step } \@results;";
                 }
             }
         }


### PR DESCRIPTION
Avoid using a code block with grep just to grep for definedness: an expression is enough.
