### PR TITLE
Fix braces

### DIFF
--- a/speedup
+++ b/speedup
@@ -12,7 +12,7 @@ my $SET_NOT_EMPTY= join( '|', qw( pcdata cdata comment)); # set the field
 # depending on the version of perl use either qr or ""
 print STDERR "perl version is $]\n";
 
-my $var= '(\$[a-z_]+(?:\[\d\])?|\$t(?:wig)?->root|\$t(?:wig)?->twig_current|\$t(?:wig)?->{\'?twig_root\'?}|\$t(?:wig)?->{\'?twig_current\'?})';
+my $var= '(\$[a-z_]+(?:\[\d\])?|\$t(?:wig)?->root|\$t(?:wig)?->twig_current|\$t(?:wig)?->\{\'?twig_root\'?\}|\$t(?:wig)?->\{\'?twig_current\'?\})';
 
 my $set_to = '(?:undef|\$\w+|\$\w+->\{\w+\}|\$\w+->\w+|\$\w+->\w+\([^)]+\))';
 my $elt    = '\$(?:elt|new_elt|child|cdata|ent|_?parent|twig_current|next_sibling|first_child|prev_sibling|last_child|ref|elt->_parent)';


### PR DESCRIPTION
Hi,

Perl 5.22 complains on braces unescaped on substitutions.
This fixes that.

Simple but useful fix, I hope.

Best
ambs