### PR TITLE
test_simplify.t does not need YAML.

### DIFF
--- a/t/test_simplify.t
+++ b/t/test_simplify.t
@@ -3,7 +3,7 @@ use strict;
 
 use XML::Twig;
 
-foreach my $module ( qw( XML::Simple Test::More Data::Dumper YAML) )
+foreach my $module ( qw( XML::Simple Test::More Data::Dumper ) ) # add YAML if using Dump() below.
   { if( eval "require $module")
       { import $module; }
     else


### PR DESCRIPTION
The call to YAML::Dump() is commented out in the distributed test_simplify.t, so there is no need for the test to SKIP if YAML is not available.
