### PR TITLE
Escape literal left braces in regular expressions

### DIFF
--- a/speedup
+++ b/speedup
@@ -12,7 +12,7 @@ my $SET_NOT_EMPTY= join( '|', qw( pcdata cdata comment)); # set the field
 # depending on the version of perl use either qr or ""
 print STDERR "perl version is $]\n";
 
-my $var= '(\$[a-z_]+(?:\[\d\])?|\$t(?:wig)?->root|\$t(?:wig)?->twig_current|\$t(?:wig)?->{\'?twig_root\'?}|\$t(?:wig)?->{\'?twig_current\'?})';
+my $var= '(\$[a-z_]+(?:\[\d\])?|\$t(?:wig)?->root|\$t(?:wig)?->twig_current|\$t(?:wig)?->\{\'?twig_root\'?}|\$t(?:wig)?->\{\'?twig_current\'?})';
 
 my $set_to = '(?:undef|\$\w+|\$\w+->\{\w+\}|\$\w+->\w+|\$\w+->\w+\([^)]+\))';
 my $elt    = '\$(?:elt|new_elt|child|cdata|ent|_?parent|twig_current|next_sibling|first_child|prev_sibling|last_child|ref|elt->_parent)';


### PR DESCRIPTION
With Perl 5.25.1, unescaped literal left braces in regular expressions
become an error. This is part of a deprecation that was begun in 5.22.

The revised code works under Perls 5.25.1,5.24.0, and 5.8.9 under Mac OS 10.11.5. These are pretty much the default build.